### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,8 @@
     SPDX-License-Identifier: Apache-2.0
 
 
-Next Version
-============
+v0.5.0
+======
 - Integration with readthe docs at https://conhead.readthedocs.io.
 - Add --show-changes which shows old header and new header.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "conhead"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python-based tool for keeping source file headers consistent."
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
- Integration with readthe docs at https://conhead.readthedocs.io.
- Add --show-changes which shows old header and new header.